### PR TITLE
Fix memory safety issue

### DIFF
--- a/Sources/Mockingjay/MockingjayProtocol.swift
+++ b/Sources/Mockingjay/MockingjayProtocol.swift
@@ -28,10 +28,35 @@ public func ==(lhs:Stub, rhs:Stub) -> Bool {
   return lhs.uuid == rhs.uuid
 }
 
-var stubs = [Stub]()
-var registered: Bool = false
+class MockingjayStorage {
+    static let shared = MockingjayStorage()
+    
+    var stubs: [Stub] {
+        get { accessQueue.sync { _stubs } }
+        set { accessQueue.sync { _stubs = newValue } }
+    }
+    
+    var registered: Bool {
+        get { accessQueue.sync { _registered } }
+        set { accessQueue.sync { _registered = newValue } }
+    }
+    
+    private var _stubs = [Stub]()
+    private var _registered: Bool = false
+    private var accessQueue: DispatchQueue { DispatchQueue(label: "MockingjayStorageQueue", qos: .default) }
+}
 
 public class MockingjayProtocol: URLProtocol {
+  private class var storage: MockingjayStorage { .shared }
+  private class var stubs: [Stub] {
+      get { storage.stubs }
+      set { storage.stubs = newValue }
+  }
+  private class var registered: Bool {
+      get { storage.registered }
+      set { storage.registered = newValue }
+  }
+  
   // MARK: Stubs
   fileprivate var enableDownloading = true
   fileprivate let operationQueue = OperationQueue()


### PR DESCRIPTION
## 経緯
Xcode15に対応した際に、CI上でテスト実行時にクラッシュが観測されることがあった。解析の結果MockingJayでクラッシュが起きている可能性が高く、[MockingJay](https://github.com/kylef/Mockingjay/)のレポジトリを見たところ[修正のPR](https://github.com/kylef/Mockingjay/pull/123)が作成されていた。

## なぜForkして対応するのか
近年MockingJayのメンテナンスは止まっており(最終更新は3年前)、この修正がマージされる見込みがなかったのでこの修正をForkしたものでマージしてZOZOTOWNへと入れようと思っています。

## 方針について
最終的には現状を踏まえて、MockingJayからの依存を切るのが良いとは思いますが、このXcode15対応のタイミングではForkしてマージで対応としたいです。
